### PR TITLE
Fixes empty prefix handling

### DIFF
--- a/src/skanlite.cpp
+++ b/src/skanlite.cpp
@@ -535,7 +535,7 @@ void Skanlite::saveImage()
 
     // Save the file base name without number
     QString baseName = QFileInfo(fileUrl.fileName()).completeBaseName();
-    while ((baseName.size() > 1) && (baseName[baseName.size() - 1].isNumber())) {
+    while ((!baseName.isEmpty()) && (baseName[baseName.size() - 1].isNumber())) {
         baseName.remove(baseName.size() - 1, 1);
     }
     m_saveLocation->u_imgPrefix->setText(baseName);


### PR DESCRIPTION
Currently if you use empty prefix you'll get filename 0001.png for your first scan, but second will be 00002.png. All further files will have 0 at beginning. SkanLite doesn't expect empty prefix and assumes first '0' of 0001.png is a prefix while continue iterating 4 digits index.