### PR TITLE
Correct display of applied filename template #2

### DIFF
--- a/src/SaveLocation.ui
+++ b/src/SaveLocation.ui
@@ -68,7 +68,7 @@
        <item>
         <widget class="QLabel" name="numberLabel">
          <property name="text">
-          <string>###.</string>
+          <string>####.</string>
          </property>
         </widget>
        </item>


### PR DESCRIPTION
Correct display of applied filename template. Iterator formatted to 4 digits, not 3.