### PR TITLE
Correct display of applied filename template #1

### DIFF
--- a/src/settings.ui
+++ b/src/settings.ui
@@ -128,7 +128,7 @@
         <item>
          <widget class="QLabel" name="label_3">
           <property name="text">
-           <string>###.</string>
+           <string>####.</string>
           </property>
          </widget>
         </item>


### PR DESCRIPTION
Correct display of applied filename template. Iterator formatted to 4 digits, not 3.