### PR TITLE
Let user start from 0 in filename iterator

### DIFF
--- a/src/SaveLocation.ui
+++ b/src/SaveLocation.ui
@@ -92,7 +92,7 @@
        <item>
         <widget class="QSpinBox" name="u_numStartFrom">
          <property name="minimum">
-          <number>1</number>
+          <number>0</number>
          </property>
          <property name="maximum">
           <number>999999</number>


### PR DESCRIPTION
Ok, let it start from 1 by default, but user will be able to manually select 0 and start from scan number 0.
Why not? I'm personally use 0 for book covers. I start from 0 if I scan the book cover or from 1 if I skip it and scan only text pages.