### PR TITLE
fix DPI info for 16bit PNG

### DIFF
--- a/src/KSaneImageSaver.cpp
+++ b/src/KSaneImageSaver.cpp
@@ -46,6 +46,7 @@ struct KSaneImageSaver::Private {
     int        m_width;
     int        m_height;
     int        m_format;
+    int        m_dpi;
     ImageType  m_type;
 
     bool savePng();
@@ -64,7 +65,7 @@ KSaneImageSaver::~KSaneImageSaver()
     delete d;
 }
 
-bool KSaneImageSaver::savePng(const QString &name, const QByteArray &data, int width, int height, int format)
+bool KSaneImageSaver::savePng(const QString &name, const QByteArray &data, int width, int height, int format, int dpi)
 {
     if (!d->m_runMutex.tryLock()) {
         return false;
@@ -75,15 +76,16 @@ bool KSaneImageSaver::savePng(const QString &name, const QByteArray &data, int w
     d->m_width  = width;
     d->m_height = height;
     d->m_format = format;
+    d->m_dpi    = dpi;
     d->m_type   = Private::ImageTypePNG;
 
     start();
     return true;
 }
 
-bool KSaneImageSaver::savePngSync(const QString &name, const QByteArray &data, int width, int height, int format)
+bool KSaneImageSaver::savePngSync(const QString &name, const QByteArray &data, int width, int height, int format, int dpi)
 {
-    if (!savePng(name, data, width, height, format)) {
+    if (!savePng(name, data, width, height, format, dpi)) {
         qDebug() << "fail";
         return false;
     }
@@ -191,6 +193,9 @@ bool KSaneImageSaver::Private::savePng()
     }
 
     png_set_sBIT(png_ptr, info_ptr, &sig_bit);
+
+    png_uint_32 dpm = m_dpi * (1000.0 / 25.4);
+    png_set_pHYs(png_ptr, info_ptr, dpm, dpm, 1);
 
     /* Optionally write comments into the image */
 //     text_ptr[0].key = "Title";

--- a/src/KSaneImageSaver.h
+++ b/src/KSaneImageSaver.h
@@ -37,9 +37,9 @@ public:
     KSaneImageSaver(QObject *parent = 0);
     ~KSaneImageSaver();
 
-    bool savePng(const QString &name, const QByteArray &data, int width, int height, int format);
+    bool savePng(const QString &name, const QByteArray &data, int width, int height, int format, int dpi);
 
-    bool savePngSync(const QString &name, const QByteArray &data, int width, int height, int format);
+    bool savePngSync(const QString &name, const QByteArray &data, int width, int height, int format, int dpi);
 
     bool saveTiff(const QString &name, const QByteArray &data, int width, int height, int format);
 

--- a/src/skanlite.cpp
+++ b/src/skanlite.cpp
@@ -498,7 +498,7 @@ void Skanlite::saveImage()
         (m_format == KSaneIface::KSaneWidget::FormatGrayScale16))
     {
         KSaneImageSaver saver;
-        if (saver.savePngSync(localName, m_data, m_width, m_height, m_format)) {
+        if (saver.savePngSync(localName, m_data, m_width, m_height, m_format, m_ksanew->currentDPI())) {
             m_showImgDialog->close(); // closing the window if it is closed should not be a problem.
         }
         else {


### PR DESCRIPTION
Skanlite tries to save 16bit PNG files on its own in KSaneImageSaver bcs KSaneWidget uses QImage to save files and QImage doesn't support 16bit images. Related warning in [libksane](https://github.com/KDE/libksane/blob/master/src/ksanewidget.h#L118)
But Skanlite doesn't add much optional PNG headers to the file. I particulary it misses  pHYs (Physical Pixel Dimensions). Without this ScanTailor app can't detect scan's dpi and forces user to choose it manually at file opening. [Related issue in scantailor](https://github.com/scantailor/scantailor/issues/250)
I've fixed this by adding pHYs to 16bit png based on KSaneWidget::currentDPI() as it [do itself](https://github.com/KDE/libksane/blob/master/src/ksanewidget.cpp#L627)