### PR TITLE
Initial version of single page PDF support

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,13 +2,16 @@ set(skanlite_SRCS main.cpp skanlite.cpp ImageViewer.cpp showimagedialog.cpp KSan
 
 ki18n_wrap_ui(skanlite_SRCS settings.ui SaveLocation.ui)
 
-#kde4_add_app_icon(skanlite_SRCS "${KDE4_INSTALL_DIR}/share/icons/oxygen/*/devices/scanner.png")
+find_package(Qt5Gui REQUIRED)
+find_package(Qt5PrintSupport REQUIRED)
 
 add_executable(skanlite ${skanlite_SRCS})
 
 target_link_libraries(skanlite
   PUBLIC
     Qt5::Core
+    Qt5::Gui
+    Qt5::PrintSupport
   PRIVATE
     KF5::CoreAddons
     KF5::Sane

--- a/src/KSaneImageSaver.h
+++ b/src/KSaneImageSaver.h
@@ -39,6 +39,8 @@ public:
 
     bool saveQImage(const QUrl &url, const QString &name, const QByteArray &data, int width, int height, int bpl, int dpi, int format, const QString& fileFormat, int quality);
     bool save16BitPng(const QUrl &url, const QString &name, const QByteArray &data, int width, int height, int bpl, int dpi, int format, const QString& fileFormat, int quality);
+
+    bool savePdf(const QUrl &url, const QString &name, const QByteArray &data, int width, int height, int bpl, int dpi, int format, const QString& fileFormat, int quality);
 Q_SIGNALS:
     void imageSaved(const QUrl &url, const QString &name, bool success);
 

--- a/src/skanlite.cpp
+++ b/src/skanlite.cpp
@@ -127,25 +127,30 @@ Skanlite::Skanlite(const QString &device, QWidget *parent)
         m_settingsUi.revertOptions->setIcon(QIcon::fromTheme(QLatin1String("edit-undo")));
         m_saveLocation = new SaveLocation(this);
 
+        m_filterList.clear();
+
         // add the supported image types
         const QList<QByteArray> tmpList = QImageWriter::supportedMimeTypes();
-        m_filterList.clear();
         foreach (auto ba, tmpList) {
             if (ba.isEmpty()) {
                 continue;
             }
             m_filterList.append(QString::fromLatin1(ba));
         }
+        // add the supported document types
+        m_filterList.append(QLatin1String("application/pdf"));
 
-        qDebug() << m_filterList;
+        qDebug() << "Supported Mime Types:" << m_filterList;
 
         // Put first class citizens at first place
+        m_filterList.removeAll(QLatin1String("application/pdf"));
         m_filterList.removeAll(QLatin1String("image/jpeg"));
         m_filterList.removeAll(QLatin1String("image/tiff"));
         m_filterList.removeAll(QLatin1String("image/png"));
         m_filterList.insert(0, QLatin1String("image/png"));
         m_filterList.insert(1, QLatin1String("image/jpeg"));
         m_filterList.insert(2, QLatin1String("image/tiff"));
+        m_filterList.insert(3, QLatin1String("application/pdf"));
 
         m_filter16BitList << QLatin1String("image/png");
         //m_filter16BitList << QLatin1String("image/tiff");
@@ -523,7 +528,11 @@ void Skanlite::saveImage()
     if (enforceSavingAsPng16bit) {
         m_imageSaver->save16BitPng(fileUrl, localName, m_data, m_width, m_height, m_bytesPerLine, (int) m_ksanew->currentDPI(), m_format, fileFormat, quality);
     } else {
-        m_imageSaver->saveQImage(fileUrl, localName, m_data, m_width, m_height, m_bytesPerLine, (int) m_ksanew->currentDPI(), m_format, fileFormat, quality);
+        if (suffix == QLatin1String("pdf")) {
+            m_imageSaver->savePdf(fileUrl, localName, m_data, m_width, m_height, m_bytesPerLine, (int) m_ksanew->currentDPI(), m_format, fileFormat, quality);
+        } else {
+            m_imageSaver->saveQImage(fileUrl, localName, m_data, m_width, m_height, m_bytesPerLine, (int) m_ksanew->currentDPI(), m_format, fileFormat, quality);
+        }
     }
 
     m_showImgDialog->close(); // calling close() on a closed window does nothing.


### PR DESCRIPTION
Write a single QImage to a single document PDF document,
using QPdfWriter.

This is just a quick and rudimentary support for saving to PDF.
Changes are tested using the test device and an actual scanner and opening via Okular.
Also verified using pdfinfo.